### PR TITLE
make the message optional when passing in an error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -219,13 +219,13 @@ var httpErrors = {
  *
  * @returns {HttpError}
  */
-function HttpError (code) {
+function HttpError (code, error, description) {
     this.statusCode = code;
 
-    if (arguments.length < 2)
-        WError.call(this, httpErrors[this.statusCode].description);
+    if (error instanceof Error)
+        WError.call(this, error, description || httpErrors[this.statusCode].description);
     else
-        WError.apply(this, Array.prototype.slice.call(arguments, 1));
+        WError.call(this, error || httpErrors[this.statusCode].description);
 
     return this;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,15 @@ describe('http-verror', function () {
         expect(e.cause().message).to.equal('test error');
     });
 
+    it('should return Forbidden (403) error with preceding error with default message', function () {
+        var e = new errors.Forbidden(new Error('test error'));
+
+        expect(e.statusCode).to.equal(403);
+        expect(e.message).to.equal('You\'re not allowed to perform such action');
+
+        expect(e.cause().message).to.equal('test error');
+    });
+
     it('should be an instance of HttpError, which is publicly exposed', function () {
         expect(new errors.BadRequest()).to.be.an.instanceof(errors.HttpError);
         expect(new errors.NotFound()).to.be.an.instanceof(errors.HttpError);


### PR DESCRIPTION
makes the trailing error message optional when wrapping an existing error object

```
new errors.Forbidden(new Error('test error'));
```
